### PR TITLE
Change body marginTop to paddingTop

### DIFF
--- a/src/SE/UI/Navbar.elm
+++ b/src/SE/UI/Navbar.elm
@@ -923,10 +923,10 @@ global : Config msg -> Bool -> Html msg
 global config isOpen =
     Css.Global.global
         [ Css.Global.body
-            [ Css.marginTop
+            [ Css.paddingTop
                 (Css.px (brandHeight + ledHeight + mobileSearchHeight))
             , Utils.widescreen
-                [ Css.marginTop (Css.px (ribbonHeight config + brandHeight + ledHeight + megaHeight config))
+                [ Css.paddingTop (Css.px (ribbonHeight config + brandHeight + ledHeight + megaHeight config))
                 ]
             ]
         , Css.Global.html


### PR DESCRIPTION
On body with margin top, collapsing margin makes it hard to have the first element push itself down below the navbar.